### PR TITLE
fix bug in wal and add unittest

### DIFF
--- a/include/memtable/memtable.h
+++ b/include/memtable/memtable.h
@@ -55,7 +55,7 @@ public:
 
   void clear();
   std::shared_ptr<SST> flush_last(SSTBuilder &builder, std::string &sst_path,
-                                  size_t sst_id,
+                                  size_t sst_id, uint64_t &flushed_tranc_id,
                                   std::shared_ptr<BlockCache> block_cache);
   void frozen_cur_table();
   size_t get_cur_size();

--- a/src/lsm/engine.cpp
+++ b/src/lsm/engine.cpp
@@ -467,10 +467,11 @@ uint64_t LSMEngine::flush() {
   SSTBuilder builder(TomlConfig::getInstance().getLsmBlockSize(),
                      true); // 4KB block size
 
+  uint64_t flushed_tranc_id = 0;
   // 4. 将 memtable 中最旧的表写入 SST
   auto sst_path = get_sst_path(new_sst_id, 0);
   auto new_sst =
-      memtable.flush_last(builder, sst_path, new_sst_id, block_cache);
+      memtable.flush_last(builder, sst_path, new_sst_id, flushed_tranc_id, block_cache);
 
   // 5. 更新内存索引
   ssts[new_sst_id] = new_sst;
@@ -483,7 +484,7 @@ uint64_t LSMEngine::flush() {
                "Flush: Memtable flushed to SST with new sst_id={}, level=0",
                new_sst_id);
 
-  return new_sst->get_tranc_id_range().second;
+  return flushed_tranc_id;
 }
 
 std::string LSMEngine::get_sst_path(size_t sst_id, size_t target_level) {

--- a/src/memtable/memtable.cpp
+++ b/src/memtable/memtable.cpp
@@ -245,7 +245,7 @@ void MemTable::clear() {
 
 // 将最老的 memtable 写入 SST, 并返回控制类
 std::shared_ptr<SST>
-MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id,
+MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id, uint64_t &flushed_tranc_id,
                      std::shared_ptr<BlockCache> block_cache) {
   spdlog::debug("MemTable--flush_last(): Starting to flush memtable to SST{}",
                 sst_id);
@@ -279,6 +279,9 @@ MemTable::flush_last(SSTBuilder &builder, std::string &sst_path, size_t sst_id,
   std::vector<std::tuple<std::string, std::string, uint64_t>> flush_data =
       table->flush();
   for (auto &[k, v, t] : flush_data) {
+    if (k == "" && v == "") {
+      flushed_tranc_id = t;
+    }
     max_tranc_id = std::max(t, max_tranc_id);
     min_tranc_id = std::min(t, min_tranc_id);
     builder.add(k, v, t);

--- a/xmake.lua
+++ b/xmake.lua
@@ -206,10 +206,11 @@ target("test_wal")
     set_kind("binary")
     set_group("tests")
     add_files("test/test_wal.cpp")
-    add_deps("logger", "wal")  -- Added memtable and iterator dependencies
+    add_deps("logger", "wal", "lsm")  -- Added memtable and iterator dependencies
     add_includedirs("include")
     add_packages("gtest")
     add_packages("toml11", "spdlog")
+    add_links("gmock")
 
 -- 定义 示例
 target("example")


### PR DESCRIPTION
If there exist two transactions txn1, txn2, txn2 commits successfully and the system crashes after txn1 writes a WAL. 
In the original implementation, flushed_id is the largest tranc_id in the memtable, at which point txn1's WAL is ignored on recovery. 
In this modification, the big and small semantics of tranc_id in WAL are removed, and a key-value pair with null key and value and tranc_id as the current transaction id is put in commit to mark the end of a transaction, and if such a key-value pair is checked in flush, flush_id will be updated. In WAL, due to the presence of locks, which are strictly linearly incremental, the logs appearing at flush_id need to be recovered at recover time.