### PR TITLE
fix: add package `gmock`, rename `$(builddir)`

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -13,7 +13,7 @@ end
 
 add_repositories("local-repo build")
 
-add_requires("gtest")
+add_requires("gtest", "gmock")
 add_requires("asio")
 add_requires("pybind11")
 add_requires("spdlog", { system = false })
@@ -113,7 +113,7 @@ target("lsm_shared")
               "src/redis_wrapper/*.cpp")
     add_packages("toml11", "spdlog")
     add_includedirs("include", {public = true})  -- 确保包含路径正确
-    set_targetdir("$(buildir)/lib")
+    set_targetdir("$(builddir)/lib")
 
     if is_plat("windows") then
         set_extension(".dll")
@@ -233,7 +233,7 @@ target("test_wal")
     add_files("test/test_wal.cpp")
     add_deps("logger", "wal", "lsm")
     add_includedirs("include", {public = true})
-    add_packages("gtest", "toml11", "spdlog")
+    add_packages("gtest", "gmock", "toml11", "spdlog")
 
 target("test_wisckey")
     set_kind("binary")
@@ -251,7 +251,7 @@ target("example")
     add_deps("logger", "config", "utils", "iterator", "skiplist", 
              "memtable", "block", "sst", "wal", "lsm", "redis")
     add_includedirs("include")  -- 显式添加包含路径
-    set_targetdir("$(buildir)/bin")
+    set_targetdir("$(builddir)/bin")
 
 target("debug")
     set_kind("binary")
@@ -259,7 +259,7 @@ target("debug")
     add_deps("logger", "config", "utils", "iterator", "skiplist", 
              "memtable", "block", "sst", "wal", "lsm", "redis")
     add_includedirs("include")  -- 显式添加包含路径
-    set_targetdir("$(buildir)/bin")
+    set_targetdir("$(builddir)/bin")
 
 target("server")
     set_kind("binary")
@@ -267,7 +267,7 @@ target("server")
     add_deps("redis")
     add_includedirs("include", {public = true})
     add_packages("asio")
-    set_targetdir("$(buildir)/bin")
+    set_targetdir("$(builddir)/bin")
 
 -- ============ Python 绑定 ============
 
@@ -279,7 +279,7 @@ if is_plat("windows") then
         add_packages("pybind11")
         add_deps("lsm")  -- Windows下使用原来的依赖
         add_includedirs("include", {public = true})
-        set_targetdir("$(buildir)/lib")
+        set_targetdir("$(builddir)/lib")
         set_filename("lsm_pybind.pyd")
         add_cxxflags("/LD")
 else
@@ -290,7 +290,7 @@ else
         add_packages("pybind11")
         add_deps("lsm_shared")  -- Unix下使用共享库依赖
         add_includedirs("include", {public = true})
-        set_targetdir("$(buildir)/lib")
+        set_targetdir("$(builddir)/lib")
         set_filename("lsm_pybind.so")
         add_ldflags("-Wl,-rpath,$ORIGIN")
         add_defines("TINYLSM_EXPORT=__attribute__((visibility(\"default\")))")


### PR DESCRIPTION
* add gmock as dependency, fix link error on linux

* rename `builddir` to eliminate warning
